### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To use this client, you must have a few things:
 1. A valid [Fitbit account](https://www.fitbit.com/signup)
 2. A [registered web application](https://dev.fitbit.com/apps/new)
   - To access the most personal information, set the `OAuth 2.0 Application Type` to `Personal`
+  - The `Redirect Url` should be http://localhost:8080
 3. The OAuth2 `CLIENT_ID` and `CLIENT_SECRET` of [your app found here](https://dev.fitbit.com/apps)
 
 ## Resources

--- a/src/body/fat.rs
+++ b/src/body/fat.rs
@@ -56,10 +56,10 @@ mod tests {
             weight_log: FatLog {
                 bmi: 23.57,
                 entry: Entry {
-                    date: NaiveDate::from_ymd(2012, 3, 5),
+                    date: NaiveDate::from_ymd_opt(2012, 3, 5).unwrap(),
                     fat: 14.5,
                     log_id: 1330991999000,
-                    time: NaiveTime::from_hms(23, 59, 59),
+                    time: NaiveTime::from_hms_opt(23, 59, 59).unwrap(),
                     source: "API".to_string(),
                 },
             },


### PR DESCRIPTION
In the Readme.md file the http://localhost:8080 was not mentioned, so most likely in #4 this step was missed. Updated the readme to include this fact.

Additionally `the from_ymd` and `from_hms` have been deprecated https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDate.html#method.from_ymd 
Changed to `from_ymd_opt` and  `from_hms_opt`